### PR TITLE
Assorted Tweaks

### DIFF
--- a/canvasGlobal.css
+++ b/canvasGlobal.css
@@ -750,8 +750,8 @@
   #kl_wrapper.kl_fp_circles_1x1 #kl_banner_image img{border: none; border-radius: 160px; }
   #kl_wrapper.kl_fp_circles_1x1 #kl_navigation {background-color: transparent; display: table; margin: -300px auto 0; overflow: hidden; position: relative; width: 660px; height: 360px; }
   #kl_wrapper.kl_fp_circles_1x1 #kl_navigation ul {width: 0px; margin: 0px; }
-  #kl_wrapper.kl_fp_circles_1x1 #kl_navigation ul li {background-color: #c2c2c2; background-image: none; border-radius: 75px; display: block; font-size: 18px; height: 130px; overflow: hidden; padding: 0; position: absolute; text-align: center; white-space: normal; width: 130px; }
-  #kl_wrapper.kl_fp_circles_1x1 #kl_navigation ul li a {background-color: #013953; color: #fff; display: block; padding: 35px 0 80px; text-align: center; width: 100%; }
+  #kl_wrapper.kl_fp_circles_1x1 #kl_navigation ul li {background-color: #013953; background-image: none; border-radius: 75px; display: block; font-size: 18px; height: 130px; overflow: hidden; padding: 0; position: absolute; text-align: center; white-space: normal; width: 130px; }
+  #kl_wrapper.kl_fp_circles_1x1 #kl_navigation ul li a {color: #fff; display: block; padding: 35px 0 80px; text-align: center; width: 100%; }
   #kl_wrapper.kl_fp_circles_1x1 #kl_navigation ul li:nth-child(1) {top: 0px; left: 0px; }
   #kl_wrapper.kl_fp_circles_1x1 #kl_navigation ul li:nth-child(2) {top: 160px; left: 0px; }
   #kl_wrapper.kl_fp_circles_1x1 #kl_navigation ul li:nth-child(3) {top: 0px; right: 0px; }
@@ -1115,7 +1115,7 @@
   /***** FP & CP COLORED HEADINGS THEME  *******************************/
   
   /* FP */
-  #kl_wrapper.kl_fp_colored_headings #kl_banner { border: none; background: #2F4661; color: #fff; margin: 0 0 5px 0; padding: 0 0 5px; }
+  #kl_wrapper.kl_fp_colored_headings #kl_banner { border: none; background: #2F4661; color: #fff; margin: 0 0 5px 0; padding: 0 0 5px; overflow: visible;}
   #kl_wrapper.kl_fp_colored_headings #kl_banner h2 { position: relative; text-align: center; text-transform: uppercase; padding: 20px 0 0;}
   #kl_wrapper.kl_fp_colored_headings #kl_banner_image { border: none; margin: 0;}
   #kl_wrapper.kl_fp_colored_headings #kl_banner #kl_banner_left {background-color: #fff; color: #696969; display: inline-block; font-size: 18px; line-height: 20px; padding: 5px 20px; position: absolute; left: 15px; top: 15px; border-bottom: 10px solid #696969;}
@@ -1192,6 +1192,14 @@
   #kl_wrapper.kl_colored_headings #kl_modules.kl_modules_tabbed li[class*=fa-]:before,
   #kl_wrapper.kl_fp_colored_headings #kl_modules.kl_modules_tabbed li[class^=fa-]:before,
   #kl_wrapper.kl_colored_headings #kl_modules.kl_modules_tabbed li[class^=fa-]:before {margin: 7px 0 5px 10px; font-size: 20px; float: left;}
+  .mceContentBody #kl_wrapper.kl_fp_colored_headings #kl_modules.kl_modules_tabbed li[class*=icon-]:before,
+  .mceContentBody #kl_wrapper.kl_colored_headings #kl_modules.kl_modules_tabbed li[class*=icon-]:before,
+  .mceContentBody #kl_wrapper.kl_fp_colored_headings #kl_modules.kl_modules_tabbed li[class^=icon-]:before,
+  .mceContentBody #kl_wrapper.kl_colored_headings #kl_modules.kl_modules_tabbed li[class^=icon-]:before,
+  .mceContentBody #kl_wrapper.kl_fp_colored_headings #kl_modules.kl_modules_tabbed li[class*=fa-]:before,
+  .mceContentBody #kl_wrapper.kl_colored_headings #kl_modules.kl_modules_tabbed li[class*=fa-]:before,
+  .mceContentBody #kl_wrapper.kl_fp_colored_headings #kl_modules.kl_modules_tabbed li[class^=fa-]:before,
+  .mceContentBody #kl_wrapper.kl_colored_headings #kl_modules.kl_modules_tabbed li[class^=fa-]:before {margin: 0 10px 0 0;}
 
 
   /* Default Headings */

--- a/canvasGlobal.css
+++ b/canvasGlobal.css
@@ -284,6 +284,7 @@
   #kl_tools .kl_success {background: #417e42; box-shadow: 0 1px 1px rgba(0,0,0,0.25); color: #ffffff; font-weight: bold; margin-bottom: 10px; padding: 5px; text-align: center; }
   .kl_border_top_rounded {border-top-right-radius: 5px; border-top-left-radius: 5px;}
   .kl_border_bottom_rounded {border-bottom-right-radius: 5px; border-bottom-left-radius: 5px;}
+  #kl_tools span.kl_current_node_title {text-transform: lowercase; color: #0099E0; font-style: italic; font-size: 12px;}
 
   /* Shrink Inputs with appended buttons in tools wrapper */
   #kl_tools .input-append input[type="text"] {font-size: 12px; height: 14px; padding: 4px; }

--- a/js/master_controls.js
+++ b/js/master_controls.js
@@ -54,7 +54,7 @@ function klPageContentCheck(klContentWrapperElement) {
     'use strict';
     var contentLoaded = false;
     // Content Pages
-    if ($('.show-content').length > 0 && $('.show-content').text().length > 50) {
+    if ($('.show-content').length > 0 && $('.show-content').children().length > 0) {
         contentLoaded = true;
     // Discussions
     } else if ($('#discussion_topic').length > 0 && $('.user_content').text().length > 0) {

--- a/js/tools_liveView.js
+++ b/js/tools_liveView.js
@@ -311,25 +311,38 @@ if (($("#kl_institutional_policies").length > 0 || $("#kl_wrapper").length > 0) 
         var title = $(value).text(),
             anchorName = title.replace("&", "");
         anchorName = anchorName.replace(/ /g, "_");
-        $(value).prepend('<a name="' + anchorName + '"></a>');
-        $("#kl_syllabus_nav_list").append('<li class="kl_' + anchorName + '_link"><a href="#' +
-            anchorName + '" class="kl_syllabus_nav_link" rel="#kl_' + anchorName + '_sub">' + title +
-            '</a></li><ul style="display:none;" id="kl_' + anchorName + '_sub" class="kl_sub_nav_list"></ul>');
-        $(value).parent('div').contents().find("h4").each(function (index, secondValue) {
-            var subtitle = $(secondValue).text(),
-                subAnchorName = subtitle.replace("&", "");
-            subAnchorName = subAnchorName.replace(/ /g, "_");
-            $(secondValue).prepend('<a name="kl_' + subAnchorName + '"></a>');
-            $('#kl_' + anchorName + '_sub').append('<li class="kl_' + subAnchorName + 'Link"><a href="#kl_' + subAnchorName + '">' + subtitle + '</a></li>');
-        });
+            // console.log('* ' + anchorName);
+        if($(value).parent('div').attr('id') !== 'kl_institutional_policies') {
+            $(value).prepend('<a name="' + anchorName + '"></a>');
+            $("#kl_syllabus_nav_list").append('<li class="kl_' + anchorName + '_link"><a href="#' +
+                anchorName + '" class="kl_syllabus_nav_link" rel="#kl_' + anchorName + '_sub">' + title +
+                '</a></li><ul style="display:none;" id="kl_' + anchorName + '_sub" class="kl_sub_nav_list"></ul>');
+            $(value).parent('div').contents().find("h4").each(function (index, secondValue) {
+                var subtitle = $(secondValue).text(),
+                    subAnchorName = subtitle.replace("&", "");
+                    console.log('-' + subtitle);
+                subAnchorName = subAnchorName.replace(/ /g, "_");
+                $(secondValue).prepend('<a name="kl_' + subAnchorName + '"></a>');
+                $('#kl_' + anchorName + '_sub').append('<li class="kl_' + subAnchorName + 'Link"><a href="#kl_' + subAnchorName + '">' + subtitle + '</a></li>');
+            });
+            
+        }
     });
-    // $(".universityPolicies h4").each(function () {
-    //     var subtitle = $(this).text(),
-    //         subAnchorName = subtitle.replace("&", "");
-    //     subAnchorName = subAnchorName.replace(/ /g, "");
-    //     $(this).prepend('<a name="' + subAnchorName + '"></a>');
-    //     $('#UNIVERSITYPOLICIESPROCEDURESSub').append('<li class="' + subAnchorName + 'Link"><a href="#' + subAnchorName + '">' + subtitle + '</a></li>');
-    // });
+    // Institutional Policies
+    var kl_policies_nav_title = $('#kl_institutional_policies h3:first').text();
+    $("#kl_syllabus_nav_list").append('<li class="kl_institutional_policies_link"><a href="#' +
+                'kl_institutional_policies" class="kl_syllabus_nav_link" rel="#kl_institutional_policies_sub">' + kl_policies_nav_title +
+                '</a></li><ul style="display:none;" id="kl_institutional_policies_sub" class="kl_sub_nav_list"></ul>');
+    $('div#kl_institutional_policies').find("h4").each(function (index, secondValue) {
+        'use strict';
+        var subtitle = $(secondValue).text(),
+            subAnchorName = subtitle.replace("&", "");
+            console.log('-' + subtitle);
+        subAnchorName = subAnchorName.replace(/ /g, "_");
+        $(secondValue).prepend('<a name="kl_' + subAnchorName + '"></a>');
+        $('#kl_institutional_policies_sub').append('<li class="kl_' + subAnchorName + 'Link"><a href="#kl_' + subAnchorName + '">' + subtitle + '</a></li>');
+    });
+
     $(".kl_syllabus_nav_link").each(function () {
         'use strict';
         var subNav = $(this).attr("rel");
@@ -342,7 +355,7 @@ if (($("#kl_institutional_policies").length > 0 || $("#kl_wrapper").length > 0) 
     $(".kl_syllabus_nav_link").click(function () {
         'use strict';
         $(".kl_sub_nav_list").slideUp();
-        $(".icon-arrow-down").addClass('icon-mini-arrow-right').removeClass('icon-mini-arrow-down');
+        $(".icon-mini-arrow-down").addClass('icon-mini-arrow-right').removeClass('icon-mini-arrow-down');
         var subNav = $(this).attr("rel");
         if ($(subNav + " li").length > 0) {
             $(subNav).slideDown();

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -1695,6 +1695,8 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             kl_spacing_val = $('#kl_' + type + '_input_all').val() + 'px';
         }
         tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type + '-' + direction, kl_spacing_val);
+        // Remove data-mce-style
+        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
     }
     function klChangeAllSpacing(type) {
         klChangeSpacing(type, 'top');

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -770,7 +770,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         });
         $('.kl_add_subtitle').unbind("click").click(function (e) {
             e.preventDefault();
-            $(iframeID).contents().find('#kl_banner_right').append('<span class="kl_subtitle">Page Subtitle</span>');
+            $(iframeID).contents().find('#kl_banner_right').append('<span class="kl_subtitle">Subtitle</span>');
             $('.kl_add_subtitle').hide();
             $('.kl_remove_subtitle').show();
         });

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -3783,7 +3783,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         klTablesReady();
     }
     function klCustomTablesButton() {
-        var tablesDialog = '<a href="#" class="btn btn-mini kl_table_dialog_trigger" style="margin-left:5px;"><i class="fa fa-table"></i> Custom Tables</a>' +
+        var tablesDialog = '<a href="#" class="btn btn-mini kl_table_dialog_trigger"><i class="fa fa-table"></i> Custom Table</a>' +
             '<div id="kl_tables_dialog" title="Custom Tables" style="display:none;">' +
             '    <div class="btn-group kl_table_options kl_option_third_wrap">' +
             '        <a href="#" class="btn btn-small active" rel=".kl_table_new">Create</a>' +
@@ -3859,7 +3859,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             '        </div>' +
             '    </div>' +
             '</div>';
-        $('.kl_add_style_to_iframe').after(tablesDialog);
+        $('#kl_tools').append(tablesDialog);
         $('.kl_table_dialog_trigger').unbind("click").click(function (e) {
             e.preventDefault();
             $('#kl_tables_dialog').dialog({ position: { my: 'right top', at: 'left top', of: '#kl_tools' }, modal: false, width: 255 });

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -266,6 +266,17 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             e.preventDefault();
             tinyMCE.DOM.addClass(tinyMCE.activeEditor.selection.getNode(), "kl_unwrap_me");
             $(iframeID).contents().find('.kl_unwrap_me').contents().unwrap();
+            $('.kl_current_node_title').html('&lt;' + tinymce.activeEditor.selection.getNode().nodeName + '&gt;');
+        });
+        $('.kl_delete_node').unbind("click").click(function (e) {
+            e.preventDefault();
+            tinyMCE.DOM.addClass(tinyMCE.activeEditor.selection.getNode(), "kl_delete_me");
+            $(iframeID).contents().find('.kl_delete_me').remove();
+        });        
+        // Adjust node title when the node changes
+        $('.kl_current_node_title').html('&lt;' + tinymce.activeEditor.selection.getNode().nodeName + '&gt;');
+        tinyMCE.activeEditor.onNodeChange.add(function () {
+            $('.kl_current_node_title').html('&lt;' + tinymce.activeEditor.selection.getNode().nodeName + '&gt;');
         });
     }
     // Clear out the blank span added when the template wrapper is first created
@@ -1903,7 +1914,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             '           </div>' +
             '       </div>' +
             '       <div id="kl_padding" class="kl_border_spacing_section" style="display:none;">' +
-            '           <h4>Padding:</h4>' +
+            '           <h4>Selected <span class="kl_current_node_title"></span> Padding:</h4>' +
             '           <div class="btn-group">' +
             '               <button id="kl_padding_current" class="btn btn-mini hide" data-tooltip="top" title="Populate Fields based on current element">Current</button>' +
             '               <button id="kl_padding_apply" class="btn btn-mini" data-tooltip="top" title="Apply Entered values to current element">Apply</button>' +
@@ -1953,7 +1964,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             '           </div>' +
             '       </div>' +
             '       <div id="kl_margins" class="kl_border_spacing_section">' +
-            '           <h4>Margins:</h4>' +
+            '           <h4>Selected <span class="kl_current_node_title"></span> Margins:</h4>' +
             '           <div class="btn-group">' +
             '               <button id="kl_margins_current" class="btn btn-mini hide" data-tooltip="top" title="Populate Fields based on current element">Current</button>' +
             '               <button id="kl_margins_apply" class="btn btn-mini" data-tooltip="top" title="Apply Entered values to current element">Apply</button>' +
@@ -2113,11 +2124,11 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
     ////// Supporting functions  //////
     function klInitializeElementColorPicker(inputName, attribute) {
         var chosenColor = '',
-            // startingColor = klGetColor($(iframeID).contents().find(targetElement), attribute),
+            startingColor = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), attribute, true),
             bgHex,
             textColor;
         $(inputName).spectrum({
-            // // color: startingColor,
+            color: startingColor,
             showAlpha: true,
             preferredFormat: 'hex',
             showPaletteOnly: true,
@@ -2162,6 +2173,11 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             tinyMCE.DOM.setStyle(tinymce.activeEditor.selection.getNode(), 'border-color', '');
             tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
         });
+        tinyMCE.activeEditor.onNodeChange.add(function () {
+            klInitializeElementColorPicker('#kl_selected_element_text_color', 'color');
+            klInitializeElementColorPicker('#kl_selected_element_bg_color', 'background-color');
+            klInitializeElementColorPicker('#kl_selected_element_border_color', 'border-color');
+        });
     }
 
     ////// Custom Tools Accordion tab setup  //////
@@ -2183,7 +2199,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             '</h3>' +
             '<div id="kl_custom_buttons">' +
             '   <div class="btn-group-label kl_btn_examples kl_margin_bottom">' +
-            '       <span>Style:</span><br>' +
+            '       <span>Selected <span class="kl_current_node_title"></span> Colors:</span><br>' +
             '       <table class="table table-striped table-condensed">' +
             '       <thead><tr><th>Aspect</th><th>Color</th></tr></thead>' +
             '           <tbody>' +
@@ -5618,10 +5634,11 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             '   </div>' +
             '   <a href="#" class="btn btn-mini kl_mce_preview" rel="">Preview</a>' +
             '</div>',
-            klCleanUpButtons = '<div class="btn-group">' +
-            '   <a class="btn btn-mini kl_remove_empty" href="#" data-tooltip="left" title="This button will clean up the page contents by removing any empty elements.' +
+            klCleanUpButtons = '<a class="btn btn-mini kl_remove_empty" href="#" data-tooltip="left" title="This button will clean up the page contents by removing any empty elements.' +
             '       This is especially useful when using the <i class=\'icon-collection-save\'></i> feature."><i class="icon-trash"></i> Clear Empty Elements</a>' +
-            '   <a class="btn btn-mini kl_unwrap" href="#" data-tooltip="top" title="Remove the tag that wraps the selected element"><i class="fa fa-code"></i> Unwrap Selected</a>' +
+            '<div class="btn-group">' +
+            '   <a class="btn btn-mini kl_unwrap" href="#" data-tooltip="left" title="Remove the tag that wraps the selected element"><i class="fa fa-code"></i> Remove <span class="kl_current_node_title"></span> Tag</a>' +
+            '   <a class="btn btn-mini kl_delete_node" href="#" data-tooltip="left" title="Delete the selected element and it&lsquo;s contents"><i class="icon-end"></i> Delete <span class="kl_current_node_title"></span></a>' +
             '</div>',
             tabNavigation = '<ul>' +
             '   <li><a href="#canvas_tools" class="kl_tools_tab">Canvas Tools</a></li>' +

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -4705,7 +4705,12 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             if ($('.kl_syllabus_policies_yes').hasClass('active')) {
                 $(iframeID).contents().find('.universityPolicies').remove();
                 $(iframeID).contents().find('#kl_institutional_policies').remove();
-                $(iframeID).contents().find('body').append('<div id="kl_institutional_policies" />');
+                // If the tools were used to add content, include policies in wrapper if not, put in body
+                if ($(iframeID).contents().find('#kl_wrapper').length > 0) {
+                    $(iframeID).contents().find('#kl_wrapper').append('<div id="kl_institutional_policies" />');
+                } else {
+                    $(iframeID).contents().find('body').append('<div id="kl_institutional_policies" />');
+                }
                 $(iframeID).contents().find('#kl_institutional_policies').html(policies);
             }
         });


### PR DESCRIPTION
Tool Launching
- Changed what signified content was loaded due to text length not working on a page with just an image with alt text

Content Tools
- Added a button to delete selected element in addition to the unwrap selected element
- Show the selected element type in margins, padding, colors, and unwrap buttons
- Clear data-mce-style for margins and padding (an attribute that retains original values when editing a page)
- When node changes, the colors section shows the current colors for the selected node
- Changed default subtitle so you can double click the subtitle and type over it

Syllabus Tools
- Tweak to fix the launching of the custom tables dialog in the syllabus tools
- Policies loaded in wrapper if it exists for consistent styling.
- Fixed syllabus navigation to show links to policies h4 sections

Themes
- Minor CSS changes to the kl_fp_circles_1x1 theme and the kl_colored_headings themes
