### PR TITLE
Borders/Margins/Spacing tweak, Apple Theme and Checkmark CSS update

### DIFF
--- a/canvasGlobal.css
+++ b/canvasGlobal.css
@@ -314,7 +314,7 @@
   /* Themes Panel */
   #kl_tools .kl_active_theme:before { font-family: 'canvas-icons'; display: inline-block; vertical-align: middle; position: relative; text-rendering: optimizeLegibility; text-transform: none !important; font-weight: normal !important; font-style: normal !important; top: -1px; font-size: 16px; }
   #kl_tools .kl_active_theme  { border: 1px solid #00BD03 !important; }
-  #kl_tools .kl_active_theme:before { content: "\f1bc"; color: #00BD03; text-shadow: 1px 1px 2px #000000; left: 22px; width: 0; top: 13px; font-size: 22px; }
+  #kl_tools .kl_active_theme:before { content: "\f112"; color: #00BD03; text-shadow: 1px 1px 2px #000000; left: 22px; width: 0; top: 13px; font-size: 22px; }
   #kl_tools .kl_fp_themes .kl_active_theme:before { font-size: 40px; text-shadow: 2px 2px 2px #000000; left: 10px; width: 0; top: 5px; }
   #kl_tools .kl_fp_themes { text-align: center; overflow: hidden; }
   #kl_tools .kl_fp_themes img { width: 100px; }

--- a/canvasGlobal.css
+++ b/canvasGlobal.css
@@ -1075,7 +1075,7 @@
   #kl_wrapper.kl_apple #kl_banner #kl_banner_left{ float: left; height: 40px; border-top-left-radius: 5px; border-bottom-left-radius: 5px; }
   #kl_wrapper.kl_apple #kl_banner #kl_banner_left .kl_mod_text { display: none; }
   #kl_wrapper.kl_apple #kl_banner #kl_banner_left .kl_mod_num { display: block; height: 24px; color: #0F2439; font-size: 16px; font-weight: bold; padding: 8px 18px; margin-top: 9px; text-align: center; position: relative; top: -46px; line-height: 20px; border-top-left-radius: 5px; border-bottom-left-radius: 5px; }
-  #kl_wrapper.kl_apple #kl_banner #kl_banner_left:before { font-family: 'canvas-icons'; display: inline-block; vertical-align: middle; position: relative; text-rendering: optimizeLegibility; text-transform: none !important; font-weight: normal !important; font-style: normal !important; top: 0px;  left: 8px; color:#fff; font-size: 32px; content: "\f1cf"; }
+  #kl_wrapper.kl_apple #kl_banner #kl_banner_left:before { font-family: 'canvas-icons'; display: inline-block; vertical-align: middle; position: relative; text-rendering: optimizeLegibility; text-transform: none !important; font-weight: normal !important; font-style: normal !important; top: 0px;  left: 8px; color:#fff; font-size: 32px; content: "\f12b"; }
   #kl_wrapper.kl_apple #kl_banner #kl_banner_right { padding: 0px 10px; border-top-right-radius: 5px; }
   #kl_wrapper.kl_apple #kl_banner_right .kl_subtitle { font-size: medium; position: absolute; bottom: -30px; right: 0; color: #575757; }
   #kl_wrapper.kl_apple h3 { margin: 40px -15px 20px; border: 1px solid #BDBDBD; padding: 0 10px; border-radius: 5px; }

--- a/css/canvasMCEEditor.css
+++ b/css/canvasMCEEditor.css
@@ -207,7 +207,7 @@
 	line-height: 15px;
 }
 #kl_custom_css:after {
-	content: "\f1bc  Custom CSS";
+	content: "\f112  Custom CSS";
 }
 .kl_mce_visual_sections #kl_introduction {
 	border: 1px dashed #aa00ff;
@@ -488,7 +488,7 @@
 	font-size: 25px;
 	top: 20px;
 	left: -20px;
-	content: "\f1bc";
+	content: "\f112";
 	color: #468847;
 	text-shadow: 1px 1px 2px #000000;
 	width: 0px;
@@ -607,7 +607,7 @@
 	}
 	.kl_mce_visual_sections .kl_tabbed_section h4.kl_current_tab:before, .kl_mce_visual_sections .kl_custom_accordion h4.kl_current_acc:before {
 		font-family: 'canvas-icons';
-		content: '\f1bc';
+		content: '\f112';
 		background: #468847;
 		margin: -6px 0 0 -16px;
 		display: inline-block;

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -462,7 +462,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
 
     // Ensure that necessary sections exist for a given style, will also fix broken banner
     function klThemeElements(templateClass) {
-        var modNum, modText, modTitle, templateBanner;
+        var modNum, modText, modTitle, modSubtitle, templateBanner;
         // this first portion is designed to fix anything that might have broken
         // Look to see if kl_mod_num exists and grab value
         if ($(iframeID).contents().find('.kl_mod_num').length > 0 && $(iframeID).contents().find('.kl_mod_num').text() !== '') {
@@ -482,6 +482,18 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         } else {
             modText = 'Text ';
         }
+        // Look to see if subtitle exists and grab value and remove it
+        if ($(iframeID).contents().find('.kl_subtitle').length > 0 && $(iframeID).contents().find('.kl_subtitle').text() !== '') {
+            modSubtitle = $(iframeID).contents().find('.kl_subtitle').text();
+            if (modSubtitle === ' ') {
+                modSubtitle = 'Subtitle';
+            }
+            modSubtitle = ' <span class="kl_subtitle">' + modSubtitle + '</span>';
+            $(iframeID).contents().find('.kl_subtitle').remove();
+        } else {
+            modSubtitle = '';
+        }
+
         // Look to see if title exists and grab value
         if ($(iframeID).contents().find('#kl_banner_right').length > 0 && $(iframeID).contents().find('#kl_banner_right').text() !== '') {
             modTitle = $(iframeID).contents().find('#kl_banner_right').text();
@@ -496,7 +508,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         templateBanner = '<h2><span id="kl_banner_left">' +
             '    <span class="kl_mod_text">' + modText + ' </span><span class="kl_mod_num">' + modNum + ' </span>' +
             '</span>' +
-            '<span id="kl_banner_right">' + modTitle + '</span></h2>' +
+            '<span id="kl_banner_right">' + modTitle + modSubtitle + '</span></h2>' +
             '</div>';
         // Look to see if kl_banner is intact
         if ($(iframeID).contents().find('#kl_banner').length > 0) {

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -1784,6 +1784,8 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         $('#kl_' + type + '_input_bottom').attr('placeholder', kl_spacing_display_bottom).val('');
         $('#kl_' + type + '_input_left').attr('placeholder', kl_spacing_display_left).val('');
         $('#kl_' + type + '_input_right').attr('placeholder', kl_spacing_display_right).val('');
+        // Remove data-mce-style
+        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
     }
     function klCurrentBorder() {
         console.log('klCurrentBorder');
@@ -1815,6 +1817,8 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         klInitializeElementColorPicker('#kl_border_color_right', 'border-right-color');
         klInitializeElementColorPicker('#kl_border_color_bottom', 'border-bottom-color');
         klInitializeElementColorPicker('#kl_border_color_left', 'border-left-color');
+        // Remove data-mce-style
+        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
     }
     function klSetBorderValue(direction) {
         var kl_border_val = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), 'border-' + direction + '-width', true),
@@ -1832,6 +1836,8 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type + '-bottom', '');
         tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type + '-left', '');
         tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type + '-right', '');
+        // Remove data-mce-style
+        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
     }
 
     ////// On Ready/Click functions  //////

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -376,8 +376,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
                     // $(iframeID).contents().find(targetElement).css('color', textColor);
                     tinyMCE.DOM.setStyle(tinymce.activeEditor.selection.getNode(), 'color', textColor);
                 }
-                tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
-                // $(iframeID).contents().find(targetElement).removeAttr('data-mce-style');
+                clearDataMCEStyle();
             }
         });
     }
@@ -404,6 +403,11 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
                 $('input.' + sectionToRemove + '_section').prop('checked', false);
             }
         });
+    }
+
+    function clearDataMCEStyle() {
+        // This attribute saves styling and overwrites when saving page
+        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
     }
 
 /////////////////////////////////////////////////////////////
@@ -1734,8 +1738,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         } else {
             tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), 'border-' + direction + '-style', style);
         }
-        // Remove data-mce-style
-        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
+        clearDataMCEStyle();
     }
     function klChangeAllBorders(type) {
         var kl_border_style = $('#kl_border_style_all option:selected').val();
@@ -1753,14 +1756,14 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         } else {
             tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type + '-' + direction, kl_spacing_val);
         }
-        // Remove data-mce-style
-        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
+        clearDataMCEStyle();
     }
     function klChangeAllSpacing(type) {
         klChangeSpacing(type, 'top');
         klChangeSpacing(type, 'right');
         klChangeSpacing(type, 'bottom');
         klChangeSpacing(type, 'left');
+        clearDataMCEStyle();
     }
     function klClearSpacingInput(type) {
         $('#kl_' + type + '_input_all').attr('placeholder', '#').val('');
@@ -1770,7 +1773,6 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         $('#kl_' + type + '_input_left').attr('placeholder', '#').val('');
     }
     function klCurrentSpacing(type) {
-        console.log('klCurrentSpacing');
         var kl_spacing_top = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), type + '-top', true),
             kl_spacing_right = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), type + '-right', true),
             kl_spacing_bottom = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), type + '-bottom', true),
@@ -1784,11 +1786,8 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         $('#kl_' + type + '_input_bottom').attr('placeholder', kl_spacing_display_bottom).val('');
         $('#kl_' + type + '_input_left').attr('placeholder', kl_spacing_display_left).val('');
         $('#kl_' + type + '_input_right').attr('placeholder', kl_spacing_display_right).val('');
-        // Remove data-mce-style
-        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
     }
     function klCurrentBorder() {
-        console.log('klCurrentBorder');
         var kl_border_top = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), 'border-top-width', true),
             kl_border_right = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), 'border-right-width', true),
             kl_border_bottom = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), 'border-bottom-width', true),
@@ -1817,18 +1816,18 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         klInitializeElementColorPicker('#kl_border_color_right', 'border-right-color');
         klInitializeElementColorPicker('#kl_border_color_bottom', 'border-bottom-color');
         klInitializeElementColorPicker('#kl_border_color_left', 'border-left-color');
-        // Remove data-mce-style
-        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
     }
     function klSetBorderValue(direction) {
         var kl_border_val = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), 'border-' + direction + '-width', true),
             kl_border_display_val = kl_border_val.replace('px', '');
         $('#kl_border_input_' + direction).val(kl_border_display_val);
+        clearDataMCEStyle();
     }
     function klSetSpacingValue(type, direction) {
         var kl_spacing_val = tinyMCE.DOM.getStyle(tinyMCE.activeEditor.selection.getNode(), type + '-' + direction, true),
             kl_spacing_display_val = kl_spacing_val.replace('px', '');
         $('#kl_' + type + '_input_' + direction).val(kl_spacing_display_val);
+        clearDataMCEStyle();
     }
     function klDefaultSpacing(type) {
         tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type, '');
@@ -1836,8 +1835,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type + '-bottom', '');
         tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type + '-left', '');
         tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), type + '-right', '');
-        // Remove data-mce-style
-        tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
+        clearDataMCEStyle();
     }
 
     ////// On Ready/Click functions  //////
@@ -1902,6 +1900,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), 'border-right-color', '');
             tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), 'border-bottom-color', '');
             tinyMCE.DOM.setStyle(tinyMCE.activeEditor.selection.getNode(), 'border-left-color', '');
+            clearDataMCEStyle();
             klCurrentBorder();
             $('#kl_border_input_all').val('');
         });
@@ -2243,7 +2242,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             tinyMCE.DOM.setStyle(tinymce.activeEditor.selection.getNode(), 'background-color', '');
             tinyMCE.DOM.setStyle(tinymce.activeEditor.selection.getNode(), 'color', '');
             tinyMCE.DOM.setStyle(tinymce.activeEditor.selection.getNode(), 'border-color', '');
-            tinyMCE.DOM.setAttrib(tinymce.activeEditor.selection.getNode(), 'data-mce-style', '');
+            clearDataMCEStyle();
         });
         tinyMCE.activeEditor.onNodeChange.add(function () {
             klInitializeElementColorPicker('#kl_selected_element_text_color', 'color');


### PR DESCRIPTION
Borders/Margins/Spacing
- Some of the functions to change Tinymce styling were not removing the data-mce-style attribute of the element which resulted in changes being overwritten when page was saved

Apple Theme Fix
- Canvas changed made a change to their icon font which broke the Apple image behind the module number

Checkmark CSS Fix
- The Canvas icon-font change also impacted the checkmark used for marking
current theme, custom css, and correct answer for Quick Checks