### PR TITLE
Canvas Update and assorted tweaks

### DIFF
--- a/js/tools_liveView.js
+++ b/js/tools_liveView.js
@@ -110,7 +110,7 @@ function rgb2hex(rgb) {
     return "#" + hex(rgb[1]) + hex(rgb[2]) + hex(rgb[3]);
 }
 
-var anchor, activePanel, activeTab, bgColor, bgHex, textColor, icons, modalTitle, today, currentTheme, appendStyle, maxWidth, klStudentName;
+var anchor, activePanel, activeTab, bgColor, bgHex, colorHexArray, textColor, icons, modalTitle, today, currentTheme, appendStyle, maxWidth, klStudentName;
 // SHOW PAGES TITLE
 currentTheme = $('#kl_wrapper').attr('class');
 if ($('.kl_show_title').length === 0 && $.inArray(currentTheme, klToolsVariables.klShowPageTitleTemplates) === -1) {
@@ -432,7 +432,7 @@ if ($('#kl_modules .kl_current').length > 0 && $('.kl_modules_quick_links').leng
 }
 if ($('.kl_modules_tabbed').length > 0 && $('#wiki_page_revisions').length === 0) {
     bgColor = '';
-    bgHex = '0F2439';
+    bgHex = '545454';
     textColor = 'FFF';
     $("head").append($("<link/>", { rel: "stylesheet", href: klFontAwesomePath, type: 'text/css'}));
     $('#kl_modules').after('<div id="kl_gathering_data" class="alert alert-info"><i class="fa fa-spinner fa-spin"></i> Gathering Progress Data</div>');
@@ -443,7 +443,9 @@ if ($('.kl_modules_tabbed').length > 0 && $('#wiki_page_revisions').length === 0
     if (($('#kl_banner').length === 0 && $('#kl_navigation').length > 0) || ($('#kl_navigation').length > 0 && bgColor === 'rgba(0, 0, 0, 0)')) {
         bgColor = $('#kl_navigation').css('background-color');
     }
-    if (bgColor !== '' && bgColor !== 'rgba(0, 0, 0, 0)') {
+    // If there is a color set and it is not rgba
+    colorHexArray = bgColor.split(',');
+    if (bgColor !== '' && typeof colorHexArray[3] === 'undefined') {
         bgHex = rgb2hex(bgColor);
         bgHex = bgHex.replace('#', '');
         textColor = getContrastYIQ(bgHex);

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -1024,13 +1024,13 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
                 '<a html="#" class="kl_identify_section kl_identify_section_' + key + ' icon-collection-save" rel="' + key + '" data-tooltip="left" title="Turn selected content into <br>' + displayTitle + ' section"> Identify ' + displayTitle + ' section</a>' +
                 '</li>');
         });
-        if (toolsToLoad !== 'syllabus') {
+        if (toolsToLoad === 'syllabus' || klToolsVariables.usePHP === false) {
+            templateContentBtns = '<a href="#" class="btn btn-mini kl_sections_btn kl_margin_bottom fa fa-magic"> Template Sections</a>';
+        } else {
             templateContentBtns = '<div class="btn-group">' +
                 '   <a href="#" class="btn btn-mini kl_sections_btn kl_margin_bottom fa fa-magic"> Template Sections</a>' +
                 '   <a href="#" class="btn btn-mini kl_existing_content_btn kl_margin_bottom fa fa-files-o"> Copy Existing</a>' +
                 '</div>';
-        } else {
-            templateContentBtns = '<a href="#" class="btn btn-mini kl_sections_btn kl_margin_bottom fa fa-magic"> Template Sections</a>';
         }
         $('.kl_template_content_btn').html(templateContentBtns);
         klSectionsReady(sectionArray);
@@ -4800,7 +4800,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
 
     function klSyllabusReady() {
         // Insert notice about policies below the content editor
-        if ($('#kl_syllabus_policy_notice').length === 0) {
+        if ($('#kl_syllabus_policy_notice').length === 0 && (typeof klToolsVariables.usePHP === 'undefined' || klToolsVariables.usePHP)) {
             $('.form-actions').before('<div id="kl_syllabus_policy_notice" style="font-size:16px;">' +
                 '   <div class="btn-group">' +
                 '       <a href="#" class="btn btn-small kl_syllabus_policies_yes">Yes<span class="screenreader-only">, include policies and procedures</span></a>' +

--- a/js/tools_main.js
+++ b/js/tools_main.js
@@ -275,7 +275,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
         });        
         // Adjust node title when the node changes
         $('.kl_current_node_title').html('&lt;' + tinymce.activeEditor.selection.getNode().nodeName + '&gt;');
-        tinyMCE.activeEditor.onNodeChange.add(function () {
+        tinyMCE.activeEditor.on('NodeChange', function () {
             $('.kl_current_node_title').html('&lt;' + tinymce.activeEditor.selection.getNode().nodeName + '&gt;');
         });
     }
@@ -1972,7 +1972,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             $('#' + connectedElement).show();
         });
         // Identify when TinyMCE node changes
-        tinyMCE.activeEditor.onNodeChange.add(function () {
+        tinyMCE.activeEditor.on('NodeChange', function () {
             klCurrentSpacing('margin');
             klCurrentSpacing('padding');
             klCurrentBorder();
@@ -2242,10 +2242,6 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
 
     ////// On Ready/Click functions  //////
     function klColorsReady() {
-        $('.defaultSkin table.mceLayout .mceStatusbar div').show();
-        $('.defaultSkin table.mceLayout .mceStatusbar div').closest('tr').addClass('kl_mce_path_wrapper');
-        $('#' + tinyMCE.activeEditor.id + '_path_voice').hide();
-        $('#' + tinyMCE.activeEditor.id + '_path_row span:nth-of-type(2)').hide();
         klInitializeElementColorPicker('#kl_selected_element_text_color', 'color');
         klInitializeElementColorPicker('#kl_selected_element_bg_color', 'background-color');
         klInitializeElementColorPicker('#kl_selected_element_border_color', 'border-color');
@@ -2256,7 +2252,7 @@ klToolsArrays, vendor_legacy_normal_contrast, klAfterToolLaunch, klAdditionalAcc
             tinyMCE.DOM.setStyle(tinymce.activeEditor.selection.getNode(), 'border-color', '');
             clearDataMCEStyle();
         });
-        tinyMCE.activeEditor.onNodeChange.add(function () {
+        tinyMCE.activeEditor.on('NodeChange', function () {
             klInitializeElementColorPicker('#kl_selected_element_text_color', 'color');
             klInitializeElementColorPicker('#kl_selected_element_bg_color', 'background-color');
             klInitializeElementColorPicker('#kl_selected_element_border_color', 'border-color');

--- a/js/tools_variables-example.js
+++ b/js/tools_variables-example.js
@@ -18,9 +18,9 @@
 
 var klToolsVariables = {
 
-// //////////////////////
-// // OPTIONAL LIMITS  //
-// //////////////////////
+//////////////////////
+// OPTIONAL LIMITS  //
+//////////////////////
 
     // OPTIONAL: Limit tools loading by users roll
     klLimitByRole: false,
@@ -126,6 +126,10 @@ var klToolsVariables = {
     // You may need to update the numbers at the end
     vendor_legacy_normal_contrast: '/assets/vendor_legacy_normal_contrast.css?1408316217',
     common_legacy_normal_contrast: '/assets/common_legacy_normal_contrast.css?1408316151',
+
+    // PHP Tools: Part of the tools allow you to pull content from existing pages including institutional policies and procedures
+    // Change to false if you do not have access to PHP for this part of the tools
+    usePHP: true,
 
     // Institutional policies and procedures need to be included in a Canvas course with a page named "Policies and Procedures" include the Canvas course ID here
     klToolTemplatesCourseID: '343656',

--- a/wizard/resources/wizardAPI.php
+++ b/wizard/resources/wizardAPI.php
@@ -170,7 +170,7 @@
             return $response;
         }
         function getCourse($courseID){
-            $apiUrl = "courses/".$courseID."?include[]=term";
+            $apiUrl = "courses/".$courseID."?include[]=terms";
             $response = curlGet($apiUrl);
             return $response;
         }


### PR DESCRIPTION
- Update for editor on newest Canvas release
- Update for Canvas API update (include[]=term to include[]=terms)
- PHP tools optional: 
-- Added a variable to turn off PHP aspect of tools if unable to install
- Tabbed Module Details Color: 
-- Color detection was breaking if banner background was rgba
-- Changed default color to a dark grey instead of blue