### PR TITLE
Remnant from PHP API calls in tools

### DIFF
--- a/config-example.php
+++ b/config-example.php
@@ -51,12 +51,4 @@
 		array(16,9)
 	);
 
-	/***************************/
-	/* TOOLS API CONFIG  */
-	/***************************/
-
-	// These variables for the Content Tools to make API calls
-	$canvasDomain = 'https://<your domain>.instructure.com';
-	// This OAuth token needs to make GET API calls for any course in your institution
-	$apiToken = "###";
 ?>


### PR DESCRIPTION
I thought I removed the variables in the config file that were used
when a PHP server was required for the JavaScript tools but apparently
I had not. They were not breaking anything, just unnecessary for anyone
installing now.